### PR TITLE
gives captains the ability to edit their team name and logo

### DIFF
--- a/src/pages/roster.js
+++ b/src/pages/roster.js
@@ -1,6 +1,7 @@
 function list(templates, season, team, team_player, series, req, res) {
   var season_id = req.params.season_id
   var team_id = req.params.team_id
+  var is_team_captain = false
 
   season.getSeason(season_id).then(season => {
     return team.getTeam(team_id).then(team => {
@@ -9,6 +10,9 @@ function list(templates, season, team, team_player, series, req, res) {
           var captain = players.filter(player => {
             return player.is_captain
           })[0]
+          if (captain.steam_id == req.user.steamId) {
+            is_team_captain = true
+          }
           players = players.filter(player => {
             return !captain || player.id != captain.id
           })
@@ -35,7 +39,8 @@ function list(templates, season, team, team_player, series, req, res) {
             team: team,
             captain: captain,
             players: players,
-            series: series
+            series: series,
+            is_team_captain: is_team_captain
           })
 
           res.send(html)

--- a/src/server.js
+++ b/src/server.js
@@ -55,7 +55,7 @@ var profilePages = require('./pages/profile')(
 var seasonPages = require('./pages/seasons')(templates, season)
 var seriesPages = require('./pages/series')(
   templates, season, team, series, pairings)
-var teamPages = require('./pages/teams')(templates, season, team)
+var teamPages = require('./pages/teams')(templates, season, team, team_player)
 var registrationPages = require('./pages/registration')(
   templates, season, steam_user, team_player, player, mmr, profile)
 var rosterPages = require('./pages/roster')(

--- a/src/templates/roster/list.pug
+++ b/src/templates/roster/list.pug
@@ -73,11 +73,12 @@ block content
                     input(type='hidden' name='team_id' value=team.id)
                     input(type='hidden' name='id' value=player.id)
                     button.button.is-danger(formaction='/roster/delete' formmethod='post') Remove
-      if user && user.isAdmin
+      if user && (user.isAdmin || is_team_captain)
         div.field.is-grouped
-          p.control
-            a(href='/seasons/' + season.id + '/teams/' + team.id + '/add')
-              button.button.is-primary Add player
+          if user.isAdmin
+            p.control
+              a(href='/seasons/' + season.id + '/teams/' + team.id + '/add')
+                button.button.is-primary Add player
           p.control
             a(href='/seasons/' + season.id + '/teams/' + team.id + '/edit')
               button.button.is-primary Edit team

--- a/src/templates/team/edit.pug
+++ b/src/templates/team/edit.pug
@@ -22,19 +22,23 @@ block content
           div.field
             label.label(for='logo') Logo:
             p.control
-              input.input(id='logo' type='url' name='logo' placeholder='Logo' value=(team ? team.logo : ''))
+              input.input(id='logo' type='url' name='logo' placeholder='Logo URL' value=(team ? team.logo : ''))
           div.field
             label.label(for='seed') Seed:
             p.control
-              input.input(id='seed' type='number' name='seed' placeholder='Seed' min='0' value=(team ? team.seed : '') required)
+              if user && user.isAdmin
+                input.input(id='seed' type='number' name='seed' placeholder='Seed' min='0' value=(team ? team.seed : '') required)
+              else
+                input.input(id='seed' type='number' name='seed' placeholder='Seed' min='0' value=(team ? team.seed : '') required readOnly)
           div.field
-            p.control
-              label.checkbox
-                if team && team.disbanded
-                  input(id='disbanded' type='checkbox' name='disbanded' checked)
-                else
-                  input(id='disbanded' type='checkbox' name='disbanded')
-                span &nbsp;Disbanded?
+            if user && user.isAdmin
+              p.control
+                label.checkbox
+                  if team && team.disbanded
+                    input(id='disbanded' type='checkbox' name='disbanded' checked)
+                  else
+                    input(id='disbanded' type='checkbox' name='disbanded')
+                  span &nbsp;Disbanded?
           div.field.is-grouped
             p.control
               button.button.is-primary Submit


### PR DESCRIPTION
Gave the ability for captains to edit their team name and logos to reduce the load on the admins. 

I did end up hiding access for captains to change their seed (I imagine we don't want them to do that) and also disabled the option for them to disband their team (again, common sense)