### PR TITLE
fixed rank display for teams

### DIFF
--- a/src/repos/team_player.js
+++ b/src/repos/team_player.js
@@ -118,6 +118,12 @@ function getRoster(db, team_id) {
     steam_user.avatar,
     steam_user.solo_mmr,
     steam_user.party_mmr,
+    steam_user.rank,
+    CASE
+      WHEN profile.adjusted_rank IS NOT NULL AND profile.adjusted_rank > 0
+      THEN profile.adjusted_rank
+      ELSE steam_user.rank
+    END AS adjusted_rank,
     CASE
       WHEN profile.adjusted_mmr IS NOT NULL AND profile.adjusted_mmr > 0
       THEN profile.adjusted_mmr

--- a/src/templates/profile/view.pug
+++ b/src/templates/profile/view.pug
@@ -52,18 +52,6 @@ block content
     div.tile.is-parent
       article.tile.is-child.notification
         div.content
-          p.title Solo MMR
-          p.subtitle= profile.solo_mmr
-        div.content
-          p.title Party MMR
-          p.subtitle= profile.party_mmr
-        div.content
-          p.title Adjusted MMR
-          p.subtitle= profile.adjusted_mmr
-        div.content
-          p.title Draft MMR
-          p.subtitle= profile.draft_mmr
-        div.content
           p.title Rank
           p.subtitle= profile.rank
         div.content

--- a/src/templates/roster/list.pug
+++ b/src/templates/roster/list.pug
@@ -26,11 +26,9 @@ block content
                   a(href='/profile/' + captain.steam_id)
                     strong= captain.name
                   br
-                  | Solo MMR: #{captain.solo_mmr}
+                  | Rank: #{captain.rank}
                   br
-                  | Party MMR: #{captain.party_mmr}
-                  br
-                  | Adjusted MMR: #{captain.adjusted_mmr}
+                  | Adjusted Rank: #{captain.adjusted_rank}
               if user && user.isAdmin
                 nav.level.is-mobile
                   div.level-left
@@ -50,9 +48,8 @@ block content
           tr
             th Name
             th Avatar
-            th Solo MMR
-            th Party MMR
-            th Adjusted MMR
+            th Rank
+            th Adjusted Rank
             if user && user.isAdmin
               th Remove
         tbody
@@ -63,9 +60,8 @@ block content
               td
                 figure.image.is-32x32.hide-overflow
                   img(src=player.avatar)
-              td= player.solo_mmr
-              td= player.party_mmr
-              td= player.adjusted_mmr
+              td= player.rank
+              td= player.adjusted_rank
               if user && user.isAdmin
                 td
                   form


### PR DESCRIPTION
Changed team display to show ranks instead of MMR.
Removed MMR from showing on profile page because it is too cluttered